### PR TITLE
Bug: 326 fix switch wc

### DIFF
--- a/packages/good-design/package.json
+++ b/packages/good-design/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-flow": "^7.18.6",
     "@babel/preset-react": "^7.16.0",
     "@babel/preset-typescript": "^7.16.0",
-    "@gooddollar/web3sdk-v2": "latest",
+    "@gooddollar/web3sdk-v2": "file:.yalc/@gooddollar/web3sdk-v2",
     "@storybook/addon-actions": "^6.5.12",
     "@storybook/addon-essentials": "^6.5.12",
     "@storybook/addon-links": "^6.5.12",

--- a/packages/good-design/package.json
+++ b/packages/good-design/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gooddollar/good-design",
   "repository": "https://github.com/GoodDollar/GoodWeb3-mono/packages/good-design",
-  "version": "0.0.36",
+  "version": "0.0.36-beta.7f5c754",
   "scripts": {
     "build": "yarn dev:clean && tsc && yarn copy:assets",
     "dev:clean": "rm -fr dist types",
@@ -25,7 +25,7 @@
     "@babel/preset-flow": "^7.18.6",
     "@babel/preset-react": "^7.16.0",
     "@babel/preset-typescript": "^7.16.0",
-    "@gooddollar/web3sdk-v2": "file:.yalc/@gooddollar/web3sdk-v2",
+    "@gooddollar/web3sdk-v2": "0.1.74-beta.7f5c754",
     "@storybook/addon-actions": "^6.5.12",
     "@storybook/addon-essentials": "^6.5.12",
     "@storybook/addon-links": "^6.5.12",

--- a/packages/good-design/package.json
+++ b/packages/good-design/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gooddollar/good-design",
   "repository": "https://github.com/GoodDollar/GoodWeb3-mono/packages/good-design",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "scripts": {
     "build": "yarn dev:clean && tsc && yarn copy:assets",
     "dev:clean": "rm -fr dist types",

--- a/packages/login-sdk/package.json
+++ b/packages/login-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddollar/goodlogin-sdk",
-  "version": "1.1.23",
+  "version": "1.1.23-beta.7f5c754",
   "description": "Login SDK for login with Gooddollar wallet",
   "scripts": {
     "build": "tsc",
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@babel/preset-env": "^7.16.11",
-    "@gooddollar/web3sdk-v2": "0.1.71-beta.099e3bc",
+    "@gooddollar/web3sdk-v2": "0.1.74-beta.7f5c754",
     "@testing-library/react": "^12.1.4",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.21",

--- a/packages/sdk-v2/package.json
+++ b/packages/sdk-v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gooddollar/web3sdk-v2",
   "repository": "https://github.com/GoodDollar/GoodWeb3-mono/packages/sdk-v2",
-  "version": "0.1.73",
+  "version": "0.1.74",
   "description": "ethers and react hooks based on usedapp sdk for GoodDollar protocol",
   "scripts": {
     "build": "yarn dev:clean && ctix c && tsc",

--- a/packages/sdk-v2/package.json
+++ b/packages/sdk-v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gooddollar/web3sdk-v2",
   "repository": "https://github.com/GoodDollar/GoodWeb3-mono/packages/sdk-v2",
-  "version": "0.1.74",
+  "version": "0.1.74-beta.7f5c754",
   "description": "ethers and react hooks based on usedapp sdk for GoodDollar protocol",
   "scripts": {
     "build": "yarn dev:clean && ctix c && tsc",

--- a/packages/sdk-v2/src/sdk/onboard/modules/customwalletconnect/sdk.ts
+++ b/packages/sdk-v2/src/sdk/onboard/modules/customwalletconnect/sdk.ts
@@ -48,7 +48,7 @@ function customWcModule(options: WcConnectOptions): WalletInit {
       provider.request = async function ({ method, params }: { method: string; params?: any }) {
         if (method !== "eth_requestAccounts") {
           // new implementation of @web3-onboard/walletconnect uses a custom request
-          // which works for MetaMask, but not for GoodDollar wallet or Zengo
+          // which works for MetaMask, but is not supported by GoodDollar wallet or Zengo
           // below is the older implementation
           // where it did not support switch network requests and notified user to do it manually
           if (method === "wallet_switchEthereumChain") {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3316,7 +3316,7 @@ __metadata:
 
 "@gooddollar/web3sdk-v2@file:.yalc/@gooddollar/web3sdk-v2::locator=%40gooddollar%2Fgood-design%40workspace%3Apackages%2Fgood-design":
   version: 0.1.73
-  resolution: "@gooddollar/web3sdk-v2@file:.yalc/@gooddollar/web3sdk-v2#.yalc/@gooddollar/web3sdk-v2::hash=97fe47&locator=%40gooddollar%2Fgood-design%40workspace%3Apackages%2Fgood-design"
+  resolution: "@gooddollar/web3sdk-v2@file:.yalc/@gooddollar/web3sdk-v2#.yalc/@gooddollar/web3sdk-v2::hash=37fbe0&locator=%40gooddollar%2Fgood-design%40workspace%3Apackages%2Fgood-design"
   dependencies:
     "@amplitude/analytics-browser": ^1.6.4
     "@amplitude/analytics-react-native": ^0.7.0
@@ -3346,7 +3346,7 @@ __metadata:
     react: "*"
     react-native: "*"
     react-native-web: "*"
-  checksum: 8ab6dc785f7d68b71f7cda894f4d7972d6dbc01c6875e42d6f1bdd0214faaa87efc5dd33fd7d358b14a47eeca50225e219d14625a88efd74e6e1ec5282520458
+  checksum: d2625c0725f7172f9468436a37084e7b34ce875d77ea0b055da871c434b5424c5c23e2afd8611f8bd87ba8a23c60d64be222c8fa91d0b6b839f38b1fb23b0faa
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3134,7 +3134,7 @@ __metadata:
     "@babel/preset-typescript": ^7.16.0
     "@babel/runtime": ^7.18.9
     "@gooddollar/goodprotocol": ^2.0.1
-    "@gooddollar/web3sdk-v2": latest
+    "@gooddollar/web3sdk-v2": "file:.yalc/@gooddollar/web3sdk-v2"
     "@lingui/macro": ^3.14.0
     "@lingui/react": ^3.14.0
     "@storybook/addon-actions": ^6.5.12
@@ -3314,6 +3314,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gooddollar/web3sdk-v2@file:.yalc/@gooddollar/web3sdk-v2::locator=%40gooddollar%2Fgood-design%40workspace%3Apackages%2Fgood-design":
+  version: 0.1.73
+  resolution: "@gooddollar/web3sdk-v2@file:.yalc/@gooddollar/web3sdk-v2#.yalc/@gooddollar/web3sdk-v2::hash=97fe47&locator=%40gooddollar%2Fgood-design%40workspace%3Apackages%2Fgood-design"
+  dependencies:
+    "@amplitude/analytics-browser": ^1.6.4
+    "@amplitude/analytics-react-native": ^0.7.0
+    "@gooddollar/bridge-app": ^1.2.9
+    "@gooddollar/bridge-contracts": ^1.0.13
+    "@gooddollar/goodprotocol": ^2.0.1
+    "@react-native-firebase/analytics": ^16.4.6
+    "@sentry/browser": 7.16.0
+    "@sentry/react-native": ^4.8.0
+    "@solana/web3.js": ^1.72.0
+    "@usedapp/core": 1.2.2
+    "@web3-onboard/torus": ^2.2.1
+    "@web3auth/base": ^4.0.0
+    "@web3auth/core": ^4.0.0
+    "@web3auth/openlogin-adapter": ^4.1.0
+    "@web3auth/torus-wallet-connector-plugin": ^4.0.0
+    eventemitter3: ^4.0.7
+    mixpanel-browser: ^2.45.0
+    mixpanel-react-native: ^2.1.0
+    posthog-react-native: ^2.4.0
+    react-native-indicative: ^0.2.1
+    react-native-restart: ^0.0.24
+    react-use-promise: ^0.5.0
+  peerDependencies:
+    "@react-native-async-storage/async-storage": 1.17.10
+    ethers: 5.*
+    react: "*"
+    react-native: "*"
+    react-native-web: "*"
+  checksum: 8ab6dc785f7d68b71f7cda894f4d7972d6dbc01c6875e42d6f1bdd0214faaa87efc5dd33fd7d358b14a47eeca50225e219d14625a88efd74e6e1ec5282520458
+  languageName: node
+  linkType: hard
+
 "@gooddollar/web3sdk-v2@npm:0.1.71-beta.099e3bc":
   version: 0.1.71-beta.099e3bc
   resolution: "@gooddollar/web3sdk-v2@npm:0.1.71-beta.099e3bc"
@@ -3347,42 +3383,6 @@ __metadata:
     react-native: "*"
     react-native-web: "*"
   checksum: ca3550a0b59d43304bf3b038d3a9cfbe6ca4db0e0b23ca59e7456b8fdfbca18f7ce493645b492d44315a86ddc96479bfb77f3bdf367b3b640f021389fdff56d9
-  languageName: node
-  linkType: hard
-
-"@gooddollar/web3sdk-v2@npm:latest":
-  version: 0.1.71
-  resolution: "@gooddollar/web3sdk-v2@npm:0.1.71"
-  dependencies:
-    "@amplitude/analytics-browser": ^1.6.4
-    "@amplitude/analytics-react-native": ^0.7.0
-    "@gooddollar/bridge-app": ^1.2.9
-    "@gooddollar/bridge-contracts": ^1.0.13
-    "@gooddollar/goodprotocol": ^2.0.1
-    "@react-native-firebase/analytics": ^16.4.6
-    "@sentry/browser": 7.16.0
-    "@sentry/react-native": ^4.8.0
-    "@solana/web3.js": ^1.72.0
-    "@usedapp/core": 1.2.2
-    "@web3-onboard/torus": ^2.2.1
-    "@web3auth/base": ^4.0.0
-    "@web3auth/core": ^4.0.0
-    "@web3auth/openlogin-adapter": ^4.1.0
-    "@web3auth/torus-wallet-connector-plugin": ^4.0.0
-    eventemitter3: ^4.0.7
-    mixpanel-browser: ^2.45.0
-    mixpanel-react-native: ^2.1.0
-    posthog-react-native: ^2.4.0
-    react-native-indicative: ^0.2.1
-    react-native-restart: ^0.0.24
-    react-use-promise: ^0.5.0
-  peerDependencies:
-    "@react-native-async-storage/async-storage": 1.17.10
-    ethers: 5.*
-    react: "*"
-    react-native: "*"
-    react-native-web: "*"
-  checksum: 8794f7139ebb4b735905426fcf6a71223aed3241700a01b2a05c4d6c9de1d8c573982120d72ccfbd9544c2356a83ce6a60cb47569d65eba82f6ba310451cf817
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3134,7 +3134,7 @@ __metadata:
     "@babel/preset-typescript": ^7.16.0
     "@babel/runtime": ^7.18.9
     "@gooddollar/goodprotocol": ^2.0.1
-    "@gooddollar/web3sdk-v2": "file:.yalc/@gooddollar/web3sdk-v2"
+    "@gooddollar/web3sdk-v2": 0.1.74-beta.7f5c754
     "@lingui/macro": ^3.14.0
     "@lingui/react": ^3.14.0
     "@storybook/addon-actions": ^6.5.12
@@ -3213,7 +3213,7 @@ __metadata:
     "@babel/core": ^7.17.5
     "@babel/preset-env": ^7.16.11
     "@gooddollar/goodprotocol": 1.0.27
-    "@gooddollar/web3sdk-v2": 0.1.71-beta.099e3bc
+    "@gooddollar/web3sdk-v2": 0.1.74-beta.7f5c754
     "@testing-library/react": ^12.1.4
     "@types/jest": ^27.4.1
     "@types/node": ^17.0.21
@@ -3314,79 +3314,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gooddollar/web3sdk-v2@file:.yalc/@gooddollar/web3sdk-v2::locator=%40gooddollar%2Fgood-design%40workspace%3Apackages%2Fgood-design":
-  version: 0.1.73
-  resolution: "@gooddollar/web3sdk-v2@file:.yalc/@gooddollar/web3sdk-v2#.yalc/@gooddollar/web3sdk-v2::hash=37fbe0&locator=%40gooddollar%2Fgood-design%40workspace%3Apackages%2Fgood-design"
-  dependencies:
-    "@amplitude/analytics-browser": ^1.6.4
-    "@amplitude/analytics-react-native": ^0.7.0
-    "@gooddollar/bridge-app": ^1.2.9
-    "@gooddollar/bridge-contracts": ^1.0.13
-    "@gooddollar/goodprotocol": ^2.0.1
-    "@react-native-firebase/analytics": ^16.4.6
-    "@sentry/browser": 7.16.0
-    "@sentry/react-native": ^4.8.0
-    "@solana/web3.js": ^1.72.0
-    "@usedapp/core": 1.2.2
-    "@web3-onboard/torus": ^2.2.1
-    "@web3auth/base": ^4.0.0
-    "@web3auth/core": ^4.0.0
-    "@web3auth/openlogin-adapter": ^4.1.0
-    "@web3auth/torus-wallet-connector-plugin": ^4.0.0
-    eventemitter3: ^4.0.7
-    mixpanel-browser: ^2.45.0
-    mixpanel-react-native: ^2.1.0
-    posthog-react-native: ^2.4.0
-    react-native-indicative: ^0.2.1
-    react-native-restart: ^0.0.24
-    react-use-promise: ^0.5.0
-  peerDependencies:
-    "@react-native-async-storage/async-storage": 1.17.10
-    ethers: 5.*
-    react: "*"
-    react-native: "*"
-    react-native-web: "*"
-  checksum: d2625c0725f7172f9468436a37084e7b34ce875d77ea0b055da871c434b5424c5c23e2afd8611f8bd87ba8a23c60d64be222c8fa91d0b6b839f38b1fb23b0faa
-  languageName: node
-  linkType: hard
-
-"@gooddollar/web3sdk-v2@npm:0.1.71-beta.099e3bc":
-  version: 0.1.71-beta.099e3bc
-  resolution: "@gooddollar/web3sdk-v2@npm:0.1.71-beta.099e3bc"
-  dependencies:
-    "@amplitude/analytics-browser": ^1.6.4
-    "@amplitude/analytics-react-native": ^0.7.0
-    "@gooddollar/bridge-app": ^1.2.9
-    "@gooddollar/bridge-contracts": ^1.0.13
-    "@gooddollar/goodprotocol": ^2.0.1
-    "@react-native-firebase/analytics": ^16.4.6
-    "@sentry/browser": 7.16.0
-    "@sentry/react-native": ^4.8.0
-    "@solana/web3.js": ^1.72.0
-    "@usedapp/core": 1.2.2
-    "@web3-onboard/torus": ^2.2.1
-    "@web3auth/base": ^4.0.0
-    "@web3auth/core": ^4.0.0
-    "@web3auth/openlogin-adapter": ^4.1.0
-    "@web3auth/torus-wallet-connector-plugin": ^4.0.0
-    eventemitter3: ^4.0.7
-    mixpanel-browser: ^2.45.0
-    mixpanel-react-native: ^2.1.0
-    posthog-react-native: ^2.4.0
-    react-native-indicative: ^0.2.1
-    react-native-restart: ^0.0.24
-    react-use-promise: ^0.5.0
-  peerDependencies:
-    "@react-native-async-storage/async-storage": 1.17.10
-    ethers: 5.*
-    react: "*"
-    react-native: "*"
-    react-native-web: "*"
-  checksum: ca3550a0b59d43304bf3b038d3a9cfbe6ca4db0e0b23ca59e7456b8fdfbca18f7ce493645b492d44315a86ddc96479bfb77f3bdf367b3b640f021389fdff56d9
-  languageName: node
-  linkType: hard
-
-"@gooddollar/web3sdk-v2@workspace:packages/sdk-v2":
+"@gooddollar/web3sdk-v2@0.1.74-beta.7f5c754, @gooddollar/web3sdk-v2@workspace:packages/sdk-v2":
   version: 0.0.0-use.local
   resolution: "@gooddollar/web3sdk-v2@workspace:packages/sdk-v2"
   dependencies:


### PR DESCRIPTION
# Description

Before onboard didn't support wallet-connect switch requests at all, and just showed a modal notifying a user to do it manually. Newer implementation uses a custom request which works for metamask, but is not supported by either GD-Wallet or ZenGo (the two we currently use the customwalletconnect for)

- [x] - implement old implementation for handling switch-network requests

About # (link your issue here)
https://github.com/GoodDollar/GoodProtocolUI/issues/326

# How Has This Been Tested?
Tested with both GD-Wallet and ZenGo with new/old implementation.

# Additional context
![image](https://user-images.githubusercontent.com/6606028/221419205-878a2354-9d92-4fc3-832b-9c7e1c17997c.png)

required network shown is the one user has clicked on in the network modal