### PR TITLE
Fix: remove params from url after claiming

### DIFF
--- a/packages/good-design/src/core/buttons/ClaimButton.tsx
+++ b/packages/good-design/src/core/buttons/ClaimButton.tsx
@@ -311,18 +311,15 @@ const ClaimButton = ({
   // uses the first claimer flow
   useEffect(() => {
     const doClaim = async () => {
-      if (isVerified && account) {
+      if (!claimed && isVerified && account) {
         setFirstClaim(true);
         showActionModal();
-        await handleClaim();
         setClaimLoading(true);
-
-        // on close of modal, refresh
       }
     };
 
     doClaim().catch(noop);
-  }, [isVerified, account]);
+  }, [isVerified, account, claimed]);
 
   if (isWhitelisted && (claimed || claiming)) {
     return <FinalizationModal {...finalModalProps} />;

--- a/packages/good-design/src/core/buttons/ClaimButton.tsx
+++ b/packages/good-design/src/core/buttons/ClaimButton.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useCallback, useMemo, useState } from "react";
 import { SupportedChains, useClaim, useGetEnvChainId, useWhitelistSync, G$Amount } from "@gooddollar/web3sdk-v2";
 import { Text, View, useColorModeValue, Box, Link, HStack } from "native-base";
-
 import { useQueryParam } from "../../hooks/useQueryParam";
 import { Web3ActionButton } from "../../advanced";
 import { useFVModalAction } from "../../hooks/useFVModalAction";
@@ -214,6 +213,9 @@ const ClaimButton = ({
         showActionModal();
         await handleClaim();
         setClaimLoading(true);
+        // Here we assume claiming was completed succesfully,
+        // so it pushes the default route without params to prevent repeated claim requests
+        window.history.pushState(null, "", window.location.origin + window.location.hash);
       }
     };
 

--- a/packages/good-design/src/custom.d.ts
+++ b/packages/good-design/src/custom.d.ts
@@ -6,4 +6,4 @@ declare module "*.png" {
   const content: any;
   export default content;
 }
-///
+//

--- a/packages/good-design/src/custom.d.ts
+++ b/packages/good-design/src/custom.d.ts
@@ -6,3 +6,4 @@ declare module "*.png" {
   const content: any;
   export default content;
 }
+//


### PR DESCRIPTION
# Description

The verified param's  (set when returning after FV) triggers a claim request.
The param is never removed so it gets into a repeated claim-request loop whenever you switch pages etc.

Now after a claim, we clear the URL to its default location

About # (link your issue here)
https://github.com/GoodDollar/GoodProtocolUI/issues/357
