### PR TITLE
Fix: possible solution to getFvLink ran before connection

### DIFF
--- a/packages/sdk-v2/src/sdk/base/react.ts
+++ b/packages/sdk-v2/src/sdk/base/react.ts
@@ -129,32 +129,11 @@ export const useSDK = (
   type: SdkTypes = "base",
   requiredChainId?: number | undefined
 ): RequestedSdk["sdk"] => {
-  const { library } = useEthers();
-  const { chainId, defaultEnv } = useGetEnvChainId(requiredChainId);
-  const rolibrary = useReadOnlyProvider(chainId);
-  const [sdk, setSdk] = useState<ClaimSDK | SavingsSDK | undefined>(() =>
-    sdkFactory(
-      type,
-      defaultEnv,
-      readOnly,
-      library instanceof providers.JsonRpcProvider ? library : undefined,
-      rolibrary
-    )
-  );
+  const factory = useSDKFactory(readOnly, type, requiredChainId);
+  const [sdk, setSdk] = useState<ClaimSDK | SavingsSDK | undefined>(factory);
 
   // skip first render as sdk already initialized by useState()
-  useUpdateEffect(() => {
-    setSdk(
-      sdkFactory(
-        type,
-        defaultEnv,
-        readOnly,
-        library instanceof providers.JsonRpcProvider ? library : undefined,
-        rolibrary
-      )
-    );
-  }, [library, rolibrary, readOnly, defaultEnv, type]);
-
+  useUpdateEffect(() => void setSdk(factory()), [factory]);
   return sdk;
 };
 

--- a/packages/sdk-v2/src/sdk/base/react.ts
+++ b/packages/sdk-v2/src/sdk/base/react.ts
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState } from "react";
+import { useContext, useMemo, useState, useCallback } from "react";
 import { Signer, providers, BigNumber } from "ethers";
 import { BaseSDK, EnvKey, EnvValue } from "./sdk";
 import { TokenContext, Web3Context } from "../../contexts";
@@ -105,6 +105,24 @@ function sdkFactory(
 
   return new reqSdk(provider as providers.JsonRpcProvider, defaultEnv) as ClaimSDK | SavingsSDK;
 }
+
+export const useSDKFactory = (readOnly = false, type: SdkTypes = "base", requiredChainId?: number | undefined): any => {
+  const { library } = useEthers();
+  const { chainId, defaultEnv } = useGetEnvChainId(requiredChainId);
+  const rolibrary = useReadOnlyProvider(chainId);
+
+  return useCallback(
+    () =>
+      sdkFactory(
+        type,
+        defaultEnv,
+        readOnly,
+        library instanceof providers.JsonRpcProvider ? library : undefined,
+        rolibrary
+      ),
+    [type, defaultEnv, readOnly, library, rolibrary]
+  );
+};
 
 export const useSDK = (
   readOnly = false,

--- a/packages/sdk-v2/src/sdk/base/react.ts
+++ b/packages/sdk-v2/src/sdk/base/react.ts
@@ -98,6 +98,12 @@ function sdkFactory(
     provider = roLibrary;
   }
 
+  if (!provider && readOnly) {
+    // the only reason why there is no provider when a read-only one is requested is because there
+    // are no read-only urls set for the chain data is requested from
+    console.error("No read-only provider could be found", { type });
+  }
+
   if (!provider && !readOnly) {
     console.warn("Need a connected wallet for non-readonly sdk initializations", { type });
     return;

--- a/packages/sdk-v2/src/sdk/claim/react.ts
+++ b/packages/sdk-v2/src/sdk/claim/react.ts
@@ -3,7 +3,7 @@ import { UBIScheme } from "@gooddollar/goodprotocol/types/UBIScheme";
 import { ChainId, QueryParams, useCalls, useEthers } from "@usedapp/core";
 import { BigNumber } from "ethers";
 import { first } from "lodash";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { AsyncStorage } from "../storage";
 import usePromise from "react-use-promise";
 
@@ -11,30 +11,16 @@ import { EnvKey } from "../base/sdk";
 import { ClaimSDK } from "./sdk";
 
 import useRefreshOrNever from "../../hooks/useRefreshOrNever";
-import { useGetContract, useGetEnvChainId, useReadOnlySDK, useSDKFactory } from "../base/react";
+import { useGetContract, useGetEnvChainId, useReadOnlySDK, useSDK } from "../base/react";
 import { Envs, SupportedChains, SupportedV2Networks } from "../constants";
 import { noop } from "lodash";
 import { useContractFunctionWithDefaultGasFees } from "../base/hooks/useGasFees";
 
 export const useFVLink = (chainId?: number) => {
-  const { account } = useEthers();
   const { chainId: defaultChainId } = useGetEnvChainId();
-  const sdkFactory = useSDKFactory(false, "claim", chainId ?? defaultChainId);
-  const [fvLink, setFVLink] = useState<ClaimSDK["getFVLink"] | null>(null);
+  const sdk = useSDK(false, "claim", chainId ?? defaultChainId) as ClaimSDK;
 
-  useEffect(() => {
-    // skip effect if no account
-    if (!account) {
-      return;
-    }
-
-    const sdk = sdkFactory();
-    const link = sdk.getFVLink(chainId);
-
-    setFVLink(link);
-  }, [account, sdkFactory, chainId]);
-
-  return fvLink;
+  return useMemo(() => sdk?.getFVLink(chainId), [sdk, chainId]);
 };
 
 export const useIsAddressVerified = (address: string, env?: EnvKey) => {

--- a/packages/sdk-v2/src/sdk/claim/react.ts
+++ b/packages/sdk-v2/src/sdk/claim/react.ts
@@ -17,10 +17,12 @@ import { noop } from "lodash";
 import { useContractFunctionWithDefaultGasFees } from "../base/hooks/useGasFees";
 
 export const useFVLink = (chainId?: number) => {
+  const { account } = useEthers();
   const { chainId: defaultChainId } = useGetEnvChainId();
-  const sdk = useSDK(false, "claim", chainId ?? defaultChainId) as ClaimSDK;
 
-  return useMemo(() => sdk?.getFVLink(chainId), [sdk, chainId]);
+  const sdk = useSDK(account ? false : true, "claim", chainId ?? defaultChainId) as ClaimSDK;
+
+  return useMemo(() => sdk?.getFVLink(chainId), [sdk, chainId, account]);
 };
 
 export const useIsAddressVerified = (address: string, env?: EnvKey) => {

--- a/packages/sdk-v2/src/sdk/claim/react.ts
+++ b/packages/sdk-v2/src/sdk/claim/react.ts
@@ -20,7 +20,7 @@ export const useFVLink = (chainId?: number) => {
   const { account } = useEthers();
   const { chainId: defaultChainId } = useGetEnvChainId();
   const sdkFactory = useSDKFactory(false, "claim", chainId ?? defaultChainId);
-  const [fvLink, setFVLink] = useState<any>(null);
+  const [fvLink, setFVLink] = useState<ClaimSDK["getFVLink"] | null>(null);
 
   useEffect(() => {
     // skip effect if no account


### PR DESCRIPTION
# Description
when there is no connected account and useFvLink is called it fails to initialize the SDK properly, as there is no provider.
Since it is a hook we cannot run it conditionally higher-up, else the order-of-hooks rule will be broken

setting fv-link to read-only before connection is a potential solution
