### PR TITLE
Chore: (fix) dev-release script to reflect upcoming official version number

### DIFF
--- a/dev-release
+++ b/dev-release
@@ -15,7 +15,15 @@ const execAsync = promisify(exec)
 const writeFileAsync = promisify(writeFile)
 
 const run = (cmd, opts = {}) => execAsync(cmd, opts).then(({ stdout }) => stdout)
-const updateVersion = (version, suffix) => version.replace(/^(.?\d+\.\d+\.\d+)(.*?)$/i, `$1${suffix}`)
+const updateVersion = (version, suffix) => {
+  const match = version.match(/^(\d+\.\d+\.)(\d+)(-beta)?$/);
+  const majorMinor = match[1];
+  let updatePatch = parseInt(match[2]);
+  if (!match[3]) {
+    updatePatch = updatePatch + 1;
+  }
+  return `${majorMinor}${updatePatch}${suffix}`;
+};
 
 const writePkg = async (pkg, json) => {
   const contents = JSON.stringify(json, null, 2)


### PR DESCRIPTION
# Description

I have been updating manually the version number for the better continuation of npm version numbers
the original script kept the current patch version.
this fixes it and when its not a beta-release already, updates patch-version accoridingly

