### PR TITLE
fix: improve G$ calculator text readability

### DIFF
--- a/packages/good-design/src/apps/onramp/GdOnramperWidget.tsx
+++ b/packages/good-design/src/apps/onramp/GdOnramperWidget.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Onramper } from "./Onramper";
 import { useEthers, useEtherBalance, useTokenBalance } from "@usedapp/core";
 import { WebViewMessageEvent } from "react-native-webview";
-import { AsyncStorage, useBuyGd } from "@gooddollar/web3sdk-v2";
+import { AsyncStorage, Envs, useBuyGd, useGetEnvChainId } from "@gooddollar/web3sdk-v2";
 import { noop } from "lodash";
 
 import { useModal } from "../../hooks/useModal";
@@ -24,8 +24,6 @@ interface IGdOnramperProps {
   donateOrExecTo?: string;
   callData?: string;
   apiKey?: string;
-  urlSignature?: string;
-  onUrlSignContentReady?: (signContent: string) => void;
 }
 
 export const GdOnramperWidget = ({
@@ -35,13 +33,14 @@ export const GdOnramperWidget = ({
   withSwap = true,
   donateOrExecTo = undefined,
   callData = "0x",
-  apiKey = undefined,
-  urlSignature = undefined,
-  onUrlSignContentReady = undefined
+  apiKey = undefined
 }: IGdOnramperProps) => {
   const cusd = "0x765de816845861e75a25fca122bb6898b8b1282a";
   const { account, library } = useEthers();
   const swapLock = useRef(false);
+  const { baseEnv } = useGetEnvChainId(42220);
+  const devEnv = baseEnv === "fuse" ? "development" : baseEnv;
+  const backend = Envs[devEnv]?.backend;
 
   const { createAndSwap, swap, swapState, createState, gdHelperAddress, triggerSwapTx } = useBuyGd({
     donateOrExecTo,
@@ -59,6 +58,8 @@ export const GdOnramperWidget = ({
   const { showModal, Modal } = useModal();
 
   const [step, setStep] = useState(0);
+  const [onramperSignContent, setOnramperSignContent] = useState("");
+  const [onramperUrlSignature, setOnramperUrlSignature] = useState<string | undefined>(undefined);
 
   // console.log({ selfSwap, account, gdHelperAddress, accountCeloBalance, cusdBalance, celoBalance });
   /**
@@ -164,6 +165,48 @@ export const GdOnramperWidget = ({
     }
   }, [celoBalance, cusdBalance]);
 
+  useEffect(() => {
+    if (!onramperSignContent) return;
+
+    if (!backend) {
+      setOnramperUrlSignature(undefined);
+      console.error("Onramper: Missing backend URL for signing request");
+      return;
+    }
+
+    setOnramperUrlSignature(undefined);
+
+    const requestSignature = async () => {
+      try {
+        const response = await fetch(`${backend}/verify/onramper/sign`, {
+          method: "POST",
+          headers: { "Content-type": "application/json" },
+          body: JSON.stringify({ signContent: onramperSignContent })
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+
+        const data = await response.json();
+        const signature = data?.signature;
+
+        if (!signature) {
+          throw new Error("Invalid signature response");
+        }
+
+        setOnramperUrlSignature(signature);
+      } catch (e: any) {
+        setOnramperUrlSignature(undefined);
+        console.error("Onramper: failed to fetch URL signature", e?.message || e);
+      }
+    };
+
+    requestSignature().catch(e => {
+      console.error("Onramper: signature request failed", e);
+    });
+  }, [backend, onramperSignContent]);
+
   return (
     <>
       <Modal body={<ErrorModal />} _modalContainer={{ paddingBottom: 18, paddingLeft: 18, paddingRight: 18 }} />
@@ -178,8 +221,8 @@ export const GdOnramperWidget = ({
           isTesting={isTesting}
           onGdEvent={onEvents}
           apiKey={apiKey}
-          urlSignature={urlSignature}
-          onUrlSignContentReady={onUrlSignContentReady}
+          urlSignature={onramperUrlSignature}
+          onUrlSignContentReady={setOnramperSignContent}
         />
       </WalletAndChainGuard>
       <SignWalletModal txStatus={swapState?.status} />

--- a/packages/good-design/src/apps/onramp/GdOnramperWidget.tsx
+++ b/packages/good-design/src/apps/onramp/GdOnramperWidget.tsx
@@ -24,6 +24,8 @@ interface IGdOnramperProps {
   donateOrExecTo?: string;
   callData?: string;
   apiKey?: string;
+  urlSignature?: string;
+  onUrlSignContentReady?: (signContent: string) => void;
 }
 
 export const GdOnramperWidget = ({
@@ -33,7 +35,9 @@ export const GdOnramperWidget = ({
   withSwap = true,
   donateOrExecTo = undefined,
   callData = "0x",
-  apiKey = undefined
+  apiKey = undefined,
+  urlSignature = undefined,
+  onUrlSignContentReady = undefined
 }: IGdOnramperProps) => {
   const cusd = "0x765de816845861e75a25fca122bb6898b8b1282a";
   const { account, library } = useEthers();
@@ -174,6 +178,8 @@ export const GdOnramperWidget = ({
           isTesting={isTesting}
           onGdEvent={onEvents}
           apiKey={apiKey}
+          urlSignature={urlSignature}
+          onUrlSignContentReady={onUrlSignContentReady}
         />
       </WalletAndChainGuard>
       <SignWalletModal txStatus={swapState?.status} />

--- a/packages/good-design/src/apps/onramp/Onramper.tsx
+++ b/packages/good-design/src/apps/onramp/Onramper.tsx
@@ -1,6 +1,6 @@
-import React, { memo, useCallback, useEffect, useRef, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { WebView, WebViewMessageEvent } from "react-native-webview";
-import { Box, Circle, HStack, Stack, Text, VStack } from "native-base";
+import { Box, Circle, HStack, Stack, Text, VStack, useBreakpointValue } from "native-base";
 import { AsyncStorage, isMobile as deviceDetect } from "@gooddollar/web3sdk-v2";
 
 import { CentreBox } from "../../core/layout/CentreBox";
@@ -104,33 +104,93 @@ export const Onramper = ({
   targetNetwork?: string;
   apiKey?: string;
 }) => {
-  const url = new URL("https://buy.onramper.com/");
+  // Memoize URL construction to avoid reconstruction on every render
+  const uri = useMemo(() => {
+    const url = new URL("https://buy.onramper.com/");
 
-  if (apiKey) {
-    url.searchParams.set("apiKey", apiKey);
-  }
-  url.searchParams.set("networkWallets", `${targetNetwork}:${targetWallet}`);
-  Object.entries(widgetParams).forEach(([k, v]: [string, any]) => {
-    url.searchParams.append(k, v);
-  });
+    // Always include API key for proper authentication
+    // SECURITY NOTE: Onramper API keys are designed for client-side use
+    // - These are PUBLIC API keys specifically intended for browser environments
+    // - They are NOT secret keys and are safe to expose in client-side code
+    // - Similar to Google Maps API keys, they're restricted by domain/referrer
+    // - This follows Onramper's official integration documentation
+    // - See: https://docs.onramper.com for official security guidelines
+    if (apiKey) {
+      url.searchParams.set("apiKey", apiKey);
+    } else {
+      console.warn("Onramper: No API key provided");
+    }
+    url.searchParams.set("networkWallets", `${targetNetwork}:${targetWallet}`);
+    Object.entries(widgetParams).forEach(([k, v]: [string, any]) => {
+      if (v !== undefined) {
+        url.searchParams.set(k, String(v));
+      }
+    });
+
+    return url.toString();
+  }, [apiKey, targetNetwork, targetWallet, widgetParams]);
 
   const { title } = useWindowFocus();
 
-  const uri = url.toString();
+  // Cache AsyncStorage value to avoid repeated reads
+  const [cachedOnrampStatus, setCachedOnrampStatus] = useState<string | null>(null);
 
   const isMobile = deviceDetect();
 
+  // Responsive dimensions for the widget
+  const widgetDimensions = useBreakpointValue({
+    base: {
+      maxWidth: "100%",
+      width: "95vw",
+      height: 500,
+      webViewWidth: "100%",
+      webViewHeight: 500
+    },
+    sm: {
+      maxWidth: 400,
+      width: "90%",
+      height: 550,
+      webViewWidth: 380,
+      webViewHeight: 550
+    },
+    md: {
+      maxWidth: 450,
+      width: "80%",
+      height: 600,
+      webViewWidth: 430,
+      webViewHeight: 600
+    },
+    lg: {
+      maxWidth: 480,
+      width: "100%",
+      height: 630,
+      webViewWidth: 480,
+      webViewHeight: 630
+    },
+    xl: {
+      maxWidth: 480,
+      width: "200%",
+      height: 630,
+      webViewWidth: 480,
+      webViewHeight: 630
+    }
+  });
+
   // on page load check if a returning user is awaiting funds
+  // Cache the value to avoid repeated AsyncStorage reads
   useEffect(() => {
     const isOnramping = async () => {
-      const isOnramping = await AsyncStorage.getItem("gdOnrampSuccess");
-      if (isOnramping === "true") {
-        setStep(2);
+      if (cachedOnrampStatus === null) {
+        const status = await AsyncStorage.getItem("gdOnrampSuccess");
+        setCachedOnrampStatus(status);
+        if (status === "true") {
+          setStep(2);
+        }
       }
     };
 
     void isOnramping();
-  }, []);
+  }, [cachedOnrampStatus]);
 
   useEffect(() => {
     if (title === "Onramper widget" && step === 0) {
@@ -148,14 +208,18 @@ export const Onramper = ({
   }, [step]);
 
   if (!targetWallet) {
-    return <></>;
+    return (
+      <Box p="4" textAlign="center" color="red.500">
+        Wallet not found. Please select a valid wallet to continue.
+      </Box>
+    );
   }
 
   return (
-    <Box mb={6} alignItems="center">
+    <Box mb={6} alignItems="center" w="100%">
       <Divider orientation="horizontal" w="100%" bg="borderGrey" mb={6} />
       <Stepper step={step} />
-      <CentreBox maxWidth={420} w="100%" h={630} mb={6}>
+      <CentreBox maxWidth={widgetDimensions?.maxWidth} w={widgetDimensions?.width} h={widgetDimensions?.height} mb={6}>
         <WebView
           testID="onramper-widget-iframe-test"
           style={{
@@ -163,15 +227,25 @@ export const Onramper = ({
             borderWidth: 1,
             borderColor: "#58585f",
             borderStyle: "solid",
-            margin: "auto"
+            margin: "auto",
+            width: "100%",
+            height: "100%"
           }}
           scrollEnabled={false}
           // injectedJavaScript={jsCode} // todo: add native/web webview implementation
           webviewDebuggingEnabled={true}
           source={{ uri }}
           onMessage={onEvent}
-          height={630}
-          width={420}
+          onError={syntheticEvent => {
+            const { nativeEvent } = syntheticEvent;
+            console.error("Onramper WebView error:", nativeEvent);
+          }}
+          onHttpError={syntheticEvent => {
+            const { nativeEvent } = syntheticEvent;
+            console.error("Onramper HTTP error:", nativeEvent.statusCode, nativeEvent.description);
+          }}
+          height={widgetDimensions?.webViewHeight}
+          width={widgetDimensions?.webViewWidth}
           title="Onramper widget"
           allow="accelerometer; autoplay; camera; gyroscope; payment"
         ></WebView>

--- a/packages/good-design/src/apps/onramp/Onramper.tsx
+++ b/packages/good-design/src/apps/onramp/Onramper.tsx
@@ -218,6 +218,7 @@ export const Onramper = ({
   }, [apiKey, sensitiveParamsForSigning, signContent, widgetParams, urlSignature]);
 
   const { title } = useWindowFocus();
+  const shouldWaitForSignature = Boolean(signContent) && !urlSignature;
 
   // Cache AsyncStorage value to avoid repeated reads
   const [cachedOnrampStatus, setCachedOnrampStatus] = useState<string | null>(null);
@@ -307,35 +308,51 @@ export const Onramper = ({
       <Divider orientation="horizontal" w="100%" bg="borderGrey" mb={6} />
       <Stepper step={step} />
       <CentreBox maxWidth={widgetDimensions?.maxWidth} w={widgetDimensions?.width} h={widgetDimensions?.height} mb={6}>
-        <WebView
-          testID="onramper-widget-iframe-test"
-          style={{
-            borderRadius: 4,
-            borderWidth: 1,
-            borderColor: "#58585f",
-            borderStyle: "solid",
-            margin: "auto",
-            width: "100%",
-            height: "100%"
-          }}
-          scrollEnabled={false}
-          // injectedJavaScript={jsCode} // todo: add native/web webview implementation
-          webviewDebuggingEnabled={true}
-          source={{ uri }}
-          onMessage={onEvent}
-          onError={syntheticEvent => {
-            const { nativeEvent } = syntheticEvent;
-            console.error("Onramper WebView error:", nativeEvent);
-          }}
-          onHttpError={syntheticEvent => {
-            const { nativeEvent } = syntheticEvent;
-            console.error("Onramper HTTP error:", nativeEvent.statusCode, nativeEvent.description);
-          }}
-          height={widgetDimensions?.webViewHeight}
-          width={widgetDimensions?.webViewWidth}
-          title="Onramper widget"
-          allow="accelerometer; autoplay; camera; gyroscope; payment"
-        ></WebView>
+        {shouldWaitForSignature ? (
+          <CentreBox
+            borderRadius={4}
+            borderWidth={1}
+            borderColor="#58585f"
+            borderStyle="solid"
+            w="100%"
+            h="100%"
+            px={4}
+          >
+            <Text textAlign="center" color="goodGrey.700" fontFamily="subheading">
+              Preparing secure checkout...
+            </Text>
+          </CentreBox>
+        ) : (
+          <WebView
+            testID="onramper-widget-iframe-test"
+            style={{
+              borderRadius: 4,
+              borderWidth: 1,
+              borderColor: "#58585f",
+              borderStyle: "solid",
+              margin: "auto",
+              width: "100%",
+              height: "100%"
+            }}
+            scrollEnabled={false}
+            // injectedJavaScript={jsCode} // todo: add native/web webview implementation
+            webviewDebuggingEnabled={true}
+            source={{ uri }}
+            onMessage={onEvent}
+            onError={syntheticEvent => {
+              const { nativeEvent } = syntheticEvent;
+              console.error("Onramper WebView error:", nativeEvent);
+            }}
+            onHttpError={syntheticEvent => {
+              const { nativeEvent } = syntheticEvent;
+              console.error("Onramper HTTP error:", nativeEvent.statusCode, nativeEvent.description);
+            }}
+            height={widgetDimensions?.webViewHeight}
+            width={widgetDimensions?.webViewWidth}
+            title="Onramper widget"
+            allow="accelerometer; autoplay; camera; gyroscope; payment"
+          ></WebView>
+        )}
       </CentreBox>
       {isTesting && (
         <Box w={200} h={40} bg="gdPrimary" display="flex">

--- a/packages/good-design/src/apps/onramp/Onramper.tsx
+++ b/packages/good-design/src/apps/onramp/Onramper.tsx
@@ -10,6 +10,9 @@ import { BaseButton } from "../../core";
 import { useWindowFocus } from "../../hooks";
 
 export type OnramperCallback = (event: WebViewMessageEvent) => void;
+const SENSITIVE_WIDGET_PARAMS = ["wallets", "walletAddressTags", "networkWallets"] as const;
+type SensitiveWidgetParam = (typeof SENSITIVE_WIDGET_PARAMS)[number];
+type WidgetParams = Record<string, string | number | boolean | undefined>;
 
 const stepValues = [0, 0, 50, 50, 100, 100];
 
@@ -90,6 +93,8 @@ export const Onramper = ({
   setStep,
   isTesting,
   apiKey,
+  urlSignature,
+  onUrlSignContentReady,
   widgetParams = { onlyCryptos: "CUSD_CELO", isAddressEditable: false },
   targetNetwork = "CELO",
   targetWallet
@@ -99,11 +104,80 @@ export const Onramper = ({
   step: number;
   setStep: (step: number) => void;
   isTesting: boolean;
-  widgetParams?: any;
+  widgetParams?: WidgetParams;
   targetWallet?: string;
   targetNetwork?: string;
   apiKey?: string;
+  urlSignature?: string;
+  onUrlSignContentReady?: (signContent: string) => void;
 }) => {
+  /**
+   * Onramper URL-signing guide:
+   * - sort nested mapping keys alphabetically (e.g. "bitcoin:...,ethereum:...")
+   * - keep values unencoded while preparing signContent
+   */
+  const sortNestedMappingValueAlphabetically = useCallback((value: string) => {
+    return value
+      .split(",")
+      .filter(Boolean)
+      .map(entry => entry.trim())
+      .filter(Boolean)
+      .map(entry => {
+        const [rawKey, ...rawRest] = entry.split(":");
+        if (!rawKey || rawRest.length === 0) return undefined;
+        return [rawKey.trim().toLowerCase(), rawRest.join(":").trim()] as const;
+      })
+      .filter((pair): pair is readonly [string, string] => Boolean(pair))
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, mappedValue]) => `${key}:${mappedValue}`)
+      .join(",");
+  }, []);
+
+  const sensitiveParamsForSigning = useMemo(() => {
+    const params: Partial<Record<SensitiveWidgetParam, string>> = {};
+
+    if (targetWallet) {
+      params.networkWallets = `${targetNetwork.toLowerCase()}:${targetWallet}`;
+    }
+
+    SENSITIVE_WIDGET_PARAMS.forEach(paramKey => {
+      const widgetValue = widgetParams[paramKey];
+      if (widgetValue !== undefined) {
+        params[paramKey] = String(widgetValue);
+      }
+    });
+
+    SENSITIVE_WIDGET_PARAMS.forEach(paramKey => {
+      const sensitiveValue = params[paramKey];
+      if (sensitiveValue) {
+        params[paramKey] = sortNestedMappingValueAlphabetically(sensitiveValue);
+      }
+    });
+
+    return params;
+  }, [sortNestedMappingValueAlphabetically, targetNetwork, targetWallet, widgetParams]);
+
+  /**
+   * Onramper URL-signing guide:
+   * - signContent is ONLY sensitive params subset:
+   *   wallets, networkWallets, walletAddressTags
+   * - sort top-level keys alphabetically
+   * - keep this string unencoded before signing
+   */
+  const signContent = useMemo(() => {
+    return Object.entries(sensitiveParamsForSigning)
+      .filter(([, value]) => Boolean(value))
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, value]) => `${key}=${value}`)
+      .join("&");
+  }, [sensitiveParamsForSigning]);
+
+  useEffect(() => {
+    if (onUrlSignContentReady && signContent) {
+      onUrlSignContentReady(signContent);
+    }
+  }, [signContent, onUrlSignContentReady]);
+
   // Memoize URL construction to avoid reconstruction on every render
   const uri = useMemo(() => {
     const url = new URL("https://buy.onramper.com/");
@@ -120,15 +194,28 @@ export const Onramper = ({
     } else {
       console.warn("Onramper: No API key provided");
     }
-    url.searchParams.set("networkWallets", `${targetNetwork}:${targetWallet}`);
+    Object.entries(sensitiveParamsForSigning).forEach(([key, value]) => {
+      if (value) {
+        url.searchParams.set(key, value);
+      }
+    });
+
     Object.entries(widgetParams).forEach(([k, v]: [string, any]) => {
-      if (v !== undefined) {
+      if (v !== undefined && !SENSITIVE_WIDGET_PARAMS.includes(k as SensitiveWidgetParam)) {
         url.searchParams.set(k, String(v));
       }
     });
 
+    if (urlSignature) {
+      url.searchParams.set("signature", urlSignature);
+    } else if (signContent) {
+      console.warn(
+        "Onramper: Sensitive wallet params are present but no urlSignature was provided. Checkout may be restricted."
+      );
+    }
+
     return url.toString();
-  }, [apiKey, targetNetwork, targetWallet, widgetParams]);
+  }, [apiKey, sensitiveParamsForSigning, signContent, widgetParams, urlSignature]);
 
   const { title } = useWindowFocus();
 

--- a/packages/good-design/src/core/web3/Converter.tsx
+++ b/packages/good-design/src/core/web3/Converter.tsx
@@ -19,24 +19,29 @@ interface CurrencyBoxProps {
 
 const CurrencyBox = ({ title, placeholder, logoSrc, currencyUnit, onBlur, onChangeText }: CurrencyBoxProps) => (
   <Box bg="goodWhite.100" p={4} borderRadius={2} mb={2} justifyContent="flex-start" justifyItems="flex-start">
-    <Text>{title}</Text>
+    <Text fontSize="sm" fontWeight="500" color="goodGrey.600">
+      {title}
+    </Text>
     <Divider orientation="horizontal" w="100%" bg="goodGrey.400" mb={2} mt={2} />
     <CentreBox flexDirection="row" justifyContent="space-between">
       <CentreBox alignItems="flex-start">
         <Input
-          fontSize={6}
+          fontSize="2xl"
           maxW={220}
           ml={0}
           _focus={{ backgroundColor: "none" }}
           pl={0}
           fontWeight={700}
+          color="goodGrey.800"
           placeholder={placeholder}
           variant="unstyled"
           onBlur={onBlur}
           onChangeText={onChangeText}
           overflow="hidden"
         />
-        <Text>{currencyUnit}</Text>
+        <Text fontSize="md" fontWeight="600" color="goodGrey.600" mt={1}>
+          {currencyUnit}
+        </Text>
       </CentreBox>
       <CentreBox w="100" h="50" backgroundColor="white" flexDirection="row" justifyContent="space-around">
         <Image source={logoSrc} w="8" h="8" style={{ resizeMode: "contain" }} borderRadius="md" />

--- a/packages/good-design/src/stories/apps/onramp/Onramper.stories.tsx
+++ b/packages/good-design/src/stories/apps/onramp/Onramper.stories.tsx
@@ -4,12 +4,30 @@ import { noop } from "lodash";
 import { GdOnramperWidget } from "../../../apps/onramp/GdOnramperWidget";
 import { W3Wrapper } from "../../W3Wrapper";
 
+/**
+ * GdOnramperWidget - Buy G$ flow with Onramper integration
+ *
+ * Features:
+ * - 3-step progress bar (Buy cUSD → Swap to G$ → Done)
+ * - Responsive widget dimensions for all screen sizes
+ * - Event tracking (widget_clicked, swap_started, funds_received, swap_completed)
+ * - AsyncStorage caching for better performance
+ * - Built-in Stepper component with animations
+ * - Error handling with modal display
+ *
+ * Improvements in this version:
+ * - Better event parsing (handles both 'type' and 'title' event fields)
+ * - Fixed critical bug: swap lock now resets properly on error
+ * - Added progress event emissions for UI updates
+ * - URL memoization to prevent unnecessary reconstructions
+ * - Responsive dimensions using breakpoints
+ * - Enhanced error handling for WebView
+ */
 export const OnramperWidget = {
   args: {
-    step: 0,
-    widgetParams: undefined,
-    targetWallet: "0x0",
-    targetNetwork: "CELO"
+    apiKey: undefined, // Optional: Onramper API key for production use
+    selfSwap: false, // If true, user sends swap tx; if false, backend handles it
+    withSwap: true // Enable automatic cUSD to G$ swap
   }
 };
 
@@ -17,7 +35,7 @@ export default {
   title: "Apps/Onramper",
   component: props => (
     <W3Wrapper withMetaMask={true} env="fuse">
-      <div style={{ height: "600px" }}>
+      <div style={{ height: "800px", width: "100%", display: "flex", justifyContent: "center" }}>
         <GdOnramperWidget isTesting={true} onEvents={noop} {...props} />
       </div>
     </W3Wrapper>

--- a/packages/good-design/src/stories/apps/onramp/Onramper.stories.tsx
+++ b/packages/good-design/src/stories/apps/onramp/Onramper.stories.tsx
@@ -14,14 +14,16 @@ import { W3Wrapper } from "../../W3Wrapper";
  * - AsyncStorage caching for better performance
  * - Built-in Stepper component with animations
  * - Error handling with modal display
+ * - Server-side URL signing for enhanced security
  *
- * Improvements in this version:
+ * Improvements in this version (fix/calculator-styling):
  * - Better event parsing (handles both 'type' and 'title' event fields)
  * - Fixed critical bug: swap lock now resets properly on error
- * - Added progress event emissions for UI updates
- * - URL memoization to prevent unnecessary reconstructions
- * - Responsive dimensions using breakpoints
- * - Enhanced error handling for WebView
+ * - Added progress event emissions for UI updates (funds_received, swap_started, swap_completed)
+ * - Server-side URL signing flow via backend /verify/onramper/sign endpoint
+ * - Enhanced error handling with proper lock cleanup
+ * - Dynamic backend URL detection based on environment (fuse/celo)
+ * - Improved event handling with early returns and proper type checking
  */
 export const OnramperWidget = {
   args: {

--- a/packages/good-design/src/stories/core/web3/Converter.stories.tsx
+++ b/packages/good-design/src/stories/core/web3/Converter.stories.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import Converter from "../../../core/web3/Converter";
+import { NativeBaseProvider, theme } from "../../../theme";
+
+/**
+ * Converter (G$ Calculator) - cUSD to G$ conversion calculator
+ *
+ * This story showcases the improved styling for better text readability:
+ * - Enhanced font sizes and weights for better hierarchy
+ * - Improved color contrast with goodGrey palette
+ * - Better visual separation between elements
+ * - Clearer currency unit labels
+ *
+ * Improvements in this version:
+ * - Input text: fontSize changed from "6" to "2xl" for better readability
+ * - Input color: Added "goodGrey.800" for proper contrast
+ * - Title text: fontSize "sm" with fontWeight "500" and color "goodGrey.600"
+ * - Currency unit: fontSize "md" with fontWeight "600" for better emphasis
+ * - Overall improved visual hierarchy and readability
+ */
+export default {
+  title: "Core/Web3/Converter",
+  component: Converter,
+  decorators: [
+    (Story: any) => (
+      <NativeBaseProvider theme={theme} config={{ suppressColorAccessibilityWarning: true }}>
+        <div style={{ padding: "20px", maxWidth: "400px", margin: "0 auto" }}>
+          <Story />
+        </div>
+      </NativeBaseProvider>
+    )
+  ],
+  argTypes: {
+    gdPrice: {
+      control: { type: "number", min: 0.0001, max: 1, step: 0.0001 },
+      description: "G$ price in USD (e.g., 0.01 means 1 G$ = $0.01)"
+    }
+  }
+};
+
+// Basic converter with default G$ price
+export const Default = {
+  args: {
+    gdPrice: 0.01 // 1 G$ = $0.01 USD
+  }
+};
+
+// Converter with higher G$ price
+export const HigherPrice = {
+  args: {
+    gdPrice: 0.05 // 1 G$ = $0.05 USD
+  }
+};
+
+// Converter with lower G$ price
+export const LowerPrice = {
+  args: {
+    gdPrice: 0.005 // 1 G$ = $0.005 USD
+  }
+};
+
+// Interactive example showing the styling improvements
+export const InteractiveCalculator = {
+  render: (args: any) => {
+    return (
+      <div style={{ width: "100%", padding: "20px" }}>
+        <h3 style={{ marginBottom: "20px", color: "#333" }}>G$ Calculator - Improved Styling</h3>
+        <p style={{ marginBottom: "20px", color: "#666", fontSize: "14px" }}>
+          Try typing different amounts to see the conversion in action. Notice the improved text readability with better
+          font sizes, weights, and color contrast.
+        </p>
+        <Converter {...args} />
+        <div style={{ marginTop: "20px", padding: "15px", backgroundColor: "#f5f5f5", borderRadius: "8px" }}>
+          <h4 style={{ marginBottom: "10px", fontSize: "14px", fontWeight: "600" }}>Styling Improvements:</h4>
+          <ul style={{ fontSize: "13px", color: "#555", lineHeight: "1.8" }}>
+            <li>✓ Larger input text (2xl) for better readability</li>
+            <li>✓ Proper color contrast (goodGrey.800 on inputs)</li>
+            <li>✓ Clearer labels (sm size, 500 weight)</li>
+            <li>✓ Better currency unit emphasis (md size, 600 weight)</li>
+            <li>✓ Improved visual hierarchy throughout</li>
+          </ul>
+        </div>
+      </div>
+    );
+  },
+  args: {
+    gdPrice: 0.01
+  }
+};


### PR DESCRIPTION
## Summary
 - [x] Fixes styling issues in the G$ Calculator component where input values were barely readable when the dropdown is opened. 
 - [x] Includes updated onramper widget
 - [x] Includes required URL-signing
 - [ ] [Blocked by server-side signing endpoint](https://github.com/GoodDollar/GoodServer/pull/517)

  ## Problem
  The calculator component had three Text elements with no styling applied:
  - Title text ("With", "You'll get") - no font size, weight, or color
  - Input field - using numeric fontSize instead of semantic tokens
  - Currency unit labels (cUSD/G$) - no styling at all

  This made the text very difficult to read, especially when the calculator dropdown is opened.

  ## Changes
  - **Line 22:** Added proper styling to title text
    - `fontSize="sm"`, `fontWeight="500"`, `color="goodGrey.600"`
  - **Line 27:** Updated input field styling
    - Changed from `fontSize={6}` to semantic `fontSize="2xl"`
    - Added `color="goodGrey.800"` for better contrast
  - **Line 40:** Added styling to currency unit labels
    - `fontSize="md"`, `fontWeight="600"`, `color="goodGrey.600"`, `mt={1}`

  ## Related
  - Addresses item 3 of Scoutgame task in GoodDollar/GoodProtocolUI#483
  - Related to GoodDollar/GoodProtocolUI#605

  ## Testing
  - [x] Calculator text is now readable when dropdown is opened
  - [x] Styling is consistent with Portfolio page design patterns
  - [x] Built successfully with yalc
  - [x] No breaking changes to component API

<img width="1657" height="883" alt="Screenshot 2025-12-19 at 21 50 17" src="https://github.com/user-attachments/assets/8d9bd593-65bc-4ac0-b543-129bb07329a4" />

## Demo Video

https://github.com/user-attachments/assets/e84dffbc-db9c-467f-b4fa-74ff163dcb71

Video showing Converter calculator with improved styling
