### PR TITLE
add: new gas defaults

### DIFF
--- a/packages/sdk-v2/package.json
+++ b/packages/sdk-v2/package.json
@@ -88,8 +88,6 @@
     "@sentry/browser": "7.16.0",
     "@sentry/react-native": "^5.15.1",
     "@solana/web3.js": "^1.72.0",
-    "@walletconnect/client": "^1.8.0",
-    "@walletconnect/qrcode-modal": "^1.8.0",
     "@web3-onboard/coinbase": "^2.4.1",
     "@web3-onboard/core": "^2.23.0",
     "@web3-onboard/injected-wallets": "^2.11.2",

--- a/packages/sdk-v2/src/sdk/base/hooks/useGasFees.ts
+++ b/packages/sdk-v2/src/sdk/base/hooks/useGasFees.ts
@@ -1,7 +1,7 @@
 import { useContractFunction, useEthers } from "@usedapp/core";
-import { BigNumber } from "ethers";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { pickBy } from "lodash";
+import { FeeData } from "@ethersproject/providers";
 import {
   ContractFunctionNames,
   Falsy,
@@ -9,21 +9,26 @@ import {
   TransactionOptions,
   TypedContract
 } from "@usedapp/core/dist/esm/src/model";
+import { BigNumber } from "ethers";
 
 // force gasPrice for fuse/celo
 export const useGasFees = () => {
-  const { chainId } = useEthers();
-  const gasPrice = useMemo(() => {
-    //force gas price for celo and ethereum
-    switch (chainId) {
-      case 122:
-        return BigNumber.from(11e9);
-      case 42220:
-        return BigNumber.from(25.001e9);
-    }
-  }, [chainId]);
+  const { library } = useEthers();
+  const [fees, setFees] = useState<FeeData>({
+    gasPrice: BigNumber.from(30e9),
+    maxFeePerGas: BigNumber.from(30e9),
+    maxPriorityFeePerGas: BigNumber.from(1e8),
+    lastBaseFeePerGas: BigNumber.from(30e9)
+  } as FeeData);
 
-  return pickBy({ gasPrice }, _ => _ != null);
+  useEffect(() => {
+    if (library) {
+      void library.getFeeData().then(fees => {
+        setFees(fees);
+      });
+    }
+  }, [library]);
+  return fees;
 };
 
 // wrap usedapp useContractFunction with default gas price for fuse/celo
@@ -32,7 +37,6 @@ export function useContractFunctionWithDefaultGasFees<T extends TypedContract, F
   functionName: FN,
   options?: TransactionOptions
 ) {
-  const { chainId } = useEthers();
   const { send, ...rest } = useContractFunction(contract, functionName, options);
   const gasFees = useGasFees();
   const newSend = useCallback(
@@ -42,19 +46,10 @@ export function useContractFunctionWithDefaultGasFees<T extends TypedContract, F
         const hasOpts = args.length > numberOfArgs;
         const opts = hasOpts ? args[args.length - 1] : {};
         const modifiedArgs = hasOpts ? args.slice(0, args.length - 1) : args;
-
+        // put default gas fees. use gasPrice value instead of maxFeePerGas because maxFeePerGas uses a very large buffer.
         modifiedArgs.push(
           pickBy(
-            "maxFeePerGas" in opts
-              ? {
-                  ...opts,
-                  ...(chainId === 42220
-                    ? { maxFeePerGas: 25.001e9, maxPriorityFeePerGas: 1e8 }
-                    : chainId === 50
-                    ? { maxFeePerGas: 12.5e9 }
-                    : {})
-                }
-              : { ...gasFees, ...opts },
+            { ...{ maxFeePerGas: gasFees?.gasPrice, maxPriorityFeePerGas: gasFees?.maxPriorityFeePerGas }, ...opts },
             _ => _ != null
           )
         );

--- a/packages/sdk-v2/src/sdk/claim/react.ts
+++ b/packages/sdk-v2/src/sdk/claim/react.ts
@@ -54,6 +54,7 @@ export const useIsAddressVerified = (address: string, env?: EnvKey) => {
 
 export const useMultiClaim = (poolsDetails: PoolDetails[] | undefined) => {
   const { account, chainId, library } = useEthers();
+
   const [claimFlowStatus, setStatus] = useState<{
     isClaimingDone: boolean;
     remainingClaims: number | undefined;
@@ -74,8 +75,8 @@ export const useMultiClaim = (poolsDetails: PoolDetails[] | undefined) => {
   >([]);
   const { celoWhitelisted, syncStatus } = useWhitelistSync();
 
-  const { gasPrice = BigNumber.from(25.001e9) } = useGasFees();
-  const minBalance = BigNumber.from(chainId === 42220 ? "250000" : "150000").mul(gasPrice);
+  const fees = useGasFees();
+  const minBalance = BigNumber.from(chainId === 42220 ? "250000" : "150000").mul(fees?.gasPrice ?? 0);
   const signer = (library as ethers.providers.JsonRpcProvider)?.getSigner();
 
   const { resetState, state, send } = useContractFunctionWithDefaultGasFees(contract, "claim", {

--- a/packages/sdk-v2/src/sdk/faucet/react.ts
+++ b/packages/sdk-v2/src/sdk/faucet/react.ts
@@ -37,8 +37,8 @@ export const useFaucet = (refresh: QueryParams["refresh"] = 12) => {
   const { baseEnv } = useGetEnvChainId(); // get the env the user is connected to
   const faucet = useGetContract(chainId === SupportedChains.FUSE ? "FuseFaucet" : "Faucet", true, "base") as Faucet;
 
-  const { gasPrice = BigNumber.from(25.001e9) } = useGasFees();
-  const minBalance = BigNumber.from(chainId === 42220 ? "250000" : "150000").mul(gasPrice);
+  const fees = useGasFees();
+  const minBalance = BigNumber.from(chainId === 42220 ? "250000" : "150000").mul(fees?.gasPrice ?? 0);
 
   const faucetResult = useCalls(
     [

--- a/packages/sdk-v2/src/stories/W3Wrapper.tsx
+++ b/packages/sdk-v2/src/stories/W3Wrapper.tsx
@@ -14,7 +14,7 @@ interface PageProps {
 
 const config: Config = {
   networks: [Mainnet, Fuse, Celo, Xdc],
-  readOnlyChainId: Xdc.chainId,
+  readOnlyChainId: Celo.chainId,
   readOnlyUrls: {
     122: "https://rpc.fuse.io",
     42220: "https://forno.celo.org",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5870,7 +5870,7 @@ __metadata:
     "@formatjs/intl-locale": ^4.0.0
     "@formatjs/intl-pluralrules": ^5.2.14
     "@gooddollar/goodprotocol": ^2.2.1
-    "@gooddollar/web3sdk-v2": "file:.yalc/@gooddollar/web3sdk-v2"
+    "@gooddollar/web3sdk-v2": "*"
     "@lingui/core": ^4.11.2
     "@lingui/react": ^4.11.2
     "@magiklabs/react-sdk": ^1.0.8
@@ -6032,120 +6032,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gooddollar/web3sdk-v2@file:.yalc/@gooddollar/web3sdk-v2::locator=%40gooddollar%2Fgood-design%40workspace%3Apackages%2Fgood-design":
-  version: 0.4.35+0e5d205d
-  resolution: "@gooddollar/web3sdk-v2@file:.yalc/@gooddollar/web3sdk-v2#.yalc/@gooddollar/web3sdk-v2::hash=42a490&locator=%40gooddollar%2Fgood-design%40workspace%3Apackages%2Fgood-design"
-  dependencies:
-    "@amplitude/analytics-browser": ^1.6.4
-    "@amplitude/analytics-react-native": ^0.7.0
-    "@aws-sdk/client-s3": 3.572.0
-    "@gooddollar/bridge-app": ^1.5.0
-    "@gooddollar/bridge-contracts": ^1.0.17
-    "@gooddollar/goodcollective-contracts": ^1.3.0
-    "@gooddollar/goodcollective-sdk": ^1.3.3
-    "@gooddollar/goodprotocol": ^2.2.1
-    "@react-native-community/geolocation": 3.1.0
-    "@react-native-firebase/analytics": ^16.4.6
-    "@sentry/browser": 7.16.0
-    "@sentry/react-native": ^5.15.1
-    "@solana/web3.js": ^1.72.0
-    "@web3-onboard/coinbase": ^2.4.1
-    "@web3-onboard/core": ^2.23.0
-    "@web3-onboard/injected-wallets": ^2.11.2
-    "@web3-onboard/react": ^2.10.0
-    "@web3-onboard/torus": ^2.3.1
-    "@web3-onboard/walletconnect": ^2.6.1
-    "@web3auth/base": ^4.0.0
-    "@web3auth/core": ^4.0.0
-    "@web3auth/openlogin-adapter": ^4.1.0
-    "@web3auth/torus-wallet-connector-plugin": ^4.0.0
-    base-64: ^1.0.0
-    dexie: ^3.2.4
-    dexie-react-hooks: ^1.1.7
-    ethers: 5.7.2
-    eventemitter3: ^4.0.7
-    lz-string: ^1.5.0
-    moment: 2.29.4
-    multiformats: 9.9.0
-    posthog-react-native: 2.8.1
-    react-native-indicative: ^0.2.1
-    react-native-restart: ^0.0.24
-    react-use-promise: ^0.5.0
-  peerDependencies:
-    "@react-native-async-storage/async-storage": 1.17.10
-    "@reown/appkit": 1.*
-    "@reown/appkit-adapter-wagmi": 1.*
-    "@tanstack/react-query": 5.*
-    "@usedapp/core": "*"
-    react: ">=17"
-    react-native: "*"
-    react-native-web: "*"
-    viem: 2.*
-    wagmi: 2.*
-  checksum: 5afa0136087ce7e50b7de01921beea1869b11139c9e03db1bedb07c35b6c1fc5a6941aeedd8f5a8a09cee05439487fdb8d1dfe0f08bf4263fa941689e46c39a1
-  languageName: node
-  linkType: hard
-
-"@gooddollar/web3sdk-v2@npm:0.4.3-beta.83c9b913":
-  version: 0.4.3-beta.83c9b913
-  resolution: "@gooddollar/web3sdk-v2@npm:0.4.3-beta.83c9b913"
-  dependencies:
-    "@amplitude/analytics-browser": ^1.6.4
-    "@amplitude/analytics-react-native": ^0.7.0
-    "@aws-sdk/client-s3": 3.572.0
-    "@ceramicnetwork/http-client": ^2.32.0
-    "@ceramicnetwork/stream-tile": ^2.31.0
-    "@gooddollar/bridge-app": ^1.5.0
-    "@gooddollar/bridge-contracts": ^1.0.17
-    "@gooddollar/goodcollective-contracts": ^1.3.0
-    "@gooddollar/goodcollective-sdk": ^1.3.3
-    "@gooddollar/goodprotocol": 2.0.32-beta.0
-    "@orbisclub/orbis-sdk": ^0.4.87
-    "@react-native-community/geolocation": 3.1.0
-    "@react-native-firebase/analytics": ^16.4.6
-    "@sentry/browser": 7.16.0
-    "@sentry/react-native": ^5.15.1
-    "@solana/web3.js": ^1.72.0
-    "@walletconnect/client": ^1.8.0
-    "@walletconnect/qrcode-modal": ^1.8.0
-    "@web3-onboard/coinbase": ^2.4.1
-    "@web3-onboard/core": ^2.23.0
-    "@web3-onboard/injected-wallets": ^2.11.2
-    "@web3-onboard/react": ^2.10.0
-    "@web3-onboard/torus": ^2.3.1
-    "@web3-onboard/walletconnect": ^2.6.1
-    "@web3auth/base": ^4.0.0
-    "@web3auth/core": ^4.0.0
-    "@web3auth/openlogin-adapter": ^4.1.0
-    "@web3auth/torus-wallet-connector-plugin": ^4.0.0
-    base-64: ^1.0.0
-    dexie: ^3.2.4
-    dexie-react-hooks: ^1.1.7
-    ethers: 5.7.2
-    eventemitter3: ^4.0.7
-    lz-string: ^1.5.0
-    moment: 2.29.4
-    multiformats: 9.9.0
-    posthog-react-native: 2.8.1
-    react-native-indicative: ^0.2.1
-    react-native-restart: ^0.0.24
-    react-use-promise: ^0.5.0
-  peerDependencies:
-    "@react-native-async-storage/async-storage": 1.17.10
-    "@reown/appkit": 1.*
-    "@reown/appkit-adapter-wagmi": 1.*
-    "@tanstack/react-query": 5.*
-    "@usedapp/core": "*"
-    react: ">=17"
-    react-native: "*"
-    react-native-web: "*"
-    viem: 2.*
-    wagmi: 2.*
-  checksum: 36430249c7e61432008d5a17e50b88fd53e61ae524b598db7d93c77824eaad7d96a1b8ef2ecca7293b4970b3b10a55b7fa3674c606622baea725deb520bf13f4
-  languageName: node
-  linkType: hard
-
-"@gooddollar/web3sdk-v2@workspace:packages/sdk-v2":
+"@gooddollar/web3sdk-v2@*, @gooddollar/web3sdk-v2@workspace:packages/sdk-v2":
   version: 0.0.0-use.local
   resolution: "@gooddollar/web3sdk-v2@workspace:packages/sdk-v2"
   dependencies:
@@ -6247,6 +6134,65 @@ __metadata:
     wagmi: 2.*
   languageName: unknown
   linkType: soft
+
+"@gooddollar/web3sdk-v2@npm:0.4.3-beta.83c9b913":
+  version: 0.4.3-beta.83c9b913
+  resolution: "@gooddollar/web3sdk-v2@npm:0.4.3-beta.83c9b913"
+  dependencies:
+    "@amplitude/analytics-browser": ^1.6.4
+    "@amplitude/analytics-react-native": ^0.7.0
+    "@aws-sdk/client-s3": 3.572.0
+    "@ceramicnetwork/http-client": ^2.32.0
+    "@ceramicnetwork/stream-tile": ^2.31.0
+    "@gooddollar/bridge-app": ^1.5.0
+    "@gooddollar/bridge-contracts": ^1.0.17
+    "@gooddollar/goodcollective-contracts": ^1.3.0
+    "@gooddollar/goodcollective-sdk": ^1.3.3
+    "@gooddollar/goodprotocol": 2.0.32-beta.0
+    "@orbisclub/orbis-sdk": ^0.4.87
+    "@react-native-community/geolocation": 3.1.0
+    "@react-native-firebase/analytics": ^16.4.6
+    "@sentry/browser": 7.16.0
+    "@sentry/react-native": ^5.15.1
+    "@solana/web3.js": ^1.72.0
+    "@walletconnect/client": ^1.8.0
+    "@walletconnect/qrcode-modal": ^1.8.0
+    "@web3-onboard/coinbase": ^2.4.1
+    "@web3-onboard/core": ^2.23.0
+    "@web3-onboard/injected-wallets": ^2.11.2
+    "@web3-onboard/react": ^2.10.0
+    "@web3-onboard/torus": ^2.3.1
+    "@web3-onboard/walletconnect": ^2.6.1
+    "@web3auth/base": ^4.0.0
+    "@web3auth/core": ^4.0.0
+    "@web3auth/openlogin-adapter": ^4.1.0
+    "@web3auth/torus-wallet-connector-plugin": ^4.0.0
+    base-64: ^1.0.0
+    dexie: ^3.2.4
+    dexie-react-hooks: ^1.1.7
+    ethers: 5.7.2
+    eventemitter3: ^4.0.7
+    lz-string: ^1.5.0
+    moment: 2.29.4
+    multiformats: 9.9.0
+    posthog-react-native: 2.8.1
+    react-native-indicative: ^0.2.1
+    react-native-restart: ^0.0.24
+    react-use-promise: ^0.5.0
+  peerDependencies:
+    "@react-native-async-storage/async-storage": 1.17.10
+    "@reown/appkit": 1.*
+    "@reown/appkit-adapter-wagmi": 1.*
+    "@tanstack/react-query": 5.*
+    "@usedapp/core": "*"
+    react: ">=17"
+    react-native: "*"
+    react-native-web: "*"
+    viem: 2.*
+    wagmi: 2.*
+  checksum: 36430249c7e61432008d5a17e50b88fd53e61ae524b598db7d93c77824eaad7d96a1b8ef2ecca7293b4970b3b10a55b7fa3674c606622baea725deb520bf13f4
+  languageName: node
+  linkType: hard
 
 "@gooddollar/web3sdk@workspace:packages/sdk":
   version: 0.0.0-use.local

--- a/yarn.lock
+++ b/yarn.lock
@@ -5870,7 +5870,7 @@ __metadata:
     "@formatjs/intl-locale": ^4.0.0
     "@formatjs/intl-pluralrules": ^5.2.14
     "@gooddollar/goodprotocol": ^2.2.1
-    "@gooddollar/web3sdk-v2": "*"
+    "@gooddollar/web3sdk-v2": "file:.yalc/@gooddollar/web3sdk-v2"
     "@lingui/core": ^4.11.2
     "@lingui/react": ^4.11.2
     "@magiklabs/react-sdk": ^1.0.8
@@ -6032,7 +6032,120 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gooddollar/web3sdk-v2@*, @gooddollar/web3sdk-v2@workspace:packages/sdk-v2":
+"@gooddollar/web3sdk-v2@file:.yalc/@gooddollar/web3sdk-v2::locator=%40gooddollar%2Fgood-design%40workspace%3Apackages%2Fgood-design":
+  version: 0.4.35+0e5d205d
+  resolution: "@gooddollar/web3sdk-v2@file:.yalc/@gooddollar/web3sdk-v2#.yalc/@gooddollar/web3sdk-v2::hash=42a490&locator=%40gooddollar%2Fgood-design%40workspace%3Apackages%2Fgood-design"
+  dependencies:
+    "@amplitude/analytics-browser": ^1.6.4
+    "@amplitude/analytics-react-native": ^0.7.0
+    "@aws-sdk/client-s3": 3.572.0
+    "@gooddollar/bridge-app": ^1.5.0
+    "@gooddollar/bridge-contracts": ^1.0.17
+    "@gooddollar/goodcollective-contracts": ^1.3.0
+    "@gooddollar/goodcollective-sdk": ^1.3.3
+    "@gooddollar/goodprotocol": ^2.2.1
+    "@react-native-community/geolocation": 3.1.0
+    "@react-native-firebase/analytics": ^16.4.6
+    "@sentry/browser": 7.16.0
+    "@sentry/react-native": ^5.15.1
+    "@solana/web3.js": ^1.72.0
+    "@web3-onboard/coinbase": ^2.4.1
+    "@web3-onboard/core": ^2.23.0
+    "@web3-onboard/injected-wallets": ^2.11.2
+    "@web3-onboard/react": ^2.10.0
+    "@web3-onboard/torus": ^2.3.1
+    "@web3-onboard/walletconnect": ^2.6.1
+    "@web3auth/base": ^4.0.0
+    "@web3auth/core": ^4.0.0
+    "@web3auth/openlogin-adapter": ^4.1.0
+    "@web3auth/torus-wallet-connector-plugin": ^4.0.0
+    base-64: ^1.0.0
+    dexie: ^3.2.4
+    dexie-react-hooks: ^1.1.7
+    ethers: 5.7.2
+    eventemitter3: ^4.0.7
+    lz-string: ^1.5.0
+    moment: 2.29.4
+    multiformats: 9.9.0
+    posthog-react-native: 2.8.1
+    react-native-indicative: ^0.2.1
+    react-native-restart: ^0.0.24
+    react-use-promise: ^0.5.0
+  peerDependencies:
+    "@react-native-async-storage/async-storage": 1.17.10
+    "@reown/appkit": 1.*
+    "@reown/appkit-adapter-wagmi": 1.*
+    "@tanstack/react-query": 5.*
+    "@usedapp/core": "*"
+    react: ">=17"
+    react-native: "*"
+    react-native-web: "*"
+    viem: 2.*
+    wagmi: 2.*
+  checksum: 5afa0136087ce7e50b7de01921beea1869b11139c9e03db1bedb07c35b6c1fc5a6941aeedd8f5a8a09cee05439487fdb8d1dfe0f08bf4263fa941689e46c39a1
+  languageName: node
+  linkType: hard
+
+"@gooddollar/web3sdk-v2@npm:0.4.3-beta.83c9b913":
+  version: 0.4.3-beta.83c9b913
+  resolution: "@gooddollar/web3sdk-v2@npm:0.4.3-beta.83c9b913"
+  dependencies:
+    "@amplitude/analytics-browser": ^1.6.4
+    "@amplitude/analytics-react-native": ^0.7.0
+    "@aws-sdk/client-s3": 3.572.0
+    "@ceramicnetwork/http-client": ^2.32.0
+    "@ceramicnetwork/stream-tile": ^2.31.0
+    "@gooddollar/bridge-app": ^1.5.0
+    "@gooddollar/bridge-contracts": ^1.0.17
+    "@gooddollar/goodcollective-contracts": ^1.3.0
+    "@gooddollar/goodcollective-sdk": ^1.3.3
+    "@gooddollar/goodprotocol": 2.0.32-beta.0
+    "@orbisclub/orbis-sdk": ^0.4.87
+    "@react-native-community/geolocation": 3.1.0
+    "@react-native-firebase/analytics": ^16.4.6
+    "@sentry/browser": 7.16.0
+    "@sentry/react-native": ^5.15.1
+    "@solana/web3.js": ^1.72.0
+    "@walletconnect/client": ^1.8.0
+    "@walletconnect/qrcode-modal": ^1.8.0
+    "@web3-onboard/coinbase": ^2.4.1
+    "@web3-onboard/core": ^2.23.0
+    "@web3-onboard/injected-wallets": ^2.11.2
+    "@web3-onboard/react": ^2.10.0
+    "@web3-onboard/torus": ^2.3.1
+    "@web3-onboard/walletconnect": ^2.6.1
+    "@web3auth/base": ^4.0.0
+    "@web3auth/core": ^4.0.0
+    "@web3auth/openlogin-adapter": ^4.1.0
+    "@web3auth/torus-wallet-connector-plugin": ^4.0.0
+    base-64: ^1.0.0
+    dexie: ^3.2.4
+    dexie-react-hooks: ^1.1.7
+    ethers: 5.7.2
+    eventemitter3: ^4.0.7
+    lz-string: ^1.5.0
+    moment: 2.29.4
+    multiformats: 9.9.0
+    posthog-react-native: 2.8.1
+    react-native-indicative: ^0.2.1
+    react-native-restart: ^0.0.24
+    react-use-promise: ^0.5.0
+  peerDependencies:
+    "@react-native-async-storage/async-storage": 1.17.10
+    "@reown/appkit": 1.*
+    "@reown/appkit-adapter-wagmi": 1.*
+    "@tanstack/react-query": 5.*
+    "@usedapp/core": "*"
+    react: ">=17"
+    react-native: "*"
+    react-native-web: "*"
+    viem: 2.*
+    wagmi: 2.*
+  checksum: 36430249c7e61432008d5a17e50b88fd53e61ae524b598db7d93c77824eaad7d96a1b8ef2ecca7293b4970b3b10a55b7fa3674c606622baea725deb520bf13f4
+  languageName: node
+  linkType: hard
+
+"@gooddollar/web3sdk-v2@workspace:packages/sdk-v2":
   version: 0.0.0-use.local
   resolution: "@gooddollar/web3sdk-v2@workspace:packages/sdk-v2"
   dependencies:
@@ -6073,8 +6186,6 @@ __metadata:
     "@types/react": ^18
     "@types/react-native": 0.70.4
     "@usedapp/core": ^1.2.16
-    "@walletconnect/client": ^1.8.0
-    "@walletconnect/qrcode-modal": ^1.8.0
     "@web3-onboard/coinbase": ^2.4.1
     "@web3-onboard/core": ^2.23.0
     "@web3-onboard/injected-wallets": ^2.11.2
@@ -6136,65 +6247,6 @@ __metadata:
     wagmi: 2.*
   languageName: unknown
   linkType: soft
-
-"@gooddollar/web3sdk-v2@npm:0.4.3-beta.83c9b913":
-  version: 0.4.3-beta.83c9b913
-  resolution: "@gooddollar/web3sdk-v2@npm:0.4.3-beta.83c9b913"
-  dependencies:
-    "@amplitude/analytics-browser": ^1.6.4
-    "@amplitude/analytics-react-native": ^0.7.0
-    "@aws-sdk/client-s3": 3.572.0
-    "@ceramicnetwork/http-client": ^2.32.0
-    "@ceramicnetwork/stream-tile": ^2.31.0
-    "@gooddollar/bridge-app": ^1.5.0
-    "@gooddollar/bridge-contracts": ^1.0.17
-    "@gooddollar/goodcollective-contracts": ^1.3.0
-    "@gooddollar/goodcollective-sdk": ^1.3.3
-    "@gooddollar/goodprotocol": 2.0.32-beta.0
-    "@orbisclub/orbis-sdk": ^0.4.87
-    "@react-native-community/geolocation": 3.1.0
-    "@react-native-firebase/analytics": ^16.4.6
-    "@sentry/browser": 7.16.0
-    "@sentry/react-native": ^5.15.1
-    "@solana/web3.js": ^1.72.0
-    "@walletconnect/client": ^1.8.0
-    "@walletconnect/qrcode-modal": ^1.8.0
-    "@web3-onboard/coinbase": ^2.4.1
-    "@web3-onboard/core": ^2.23.0
-    "@web3-onboard/injected-wallets": ^2.11.2
-    "@web3-onboard/react": ^2.10.0
-    "@web3-onboard/torus": ^2.3.1
-    "@web3-onboard/walletconnect": ^2.6.1
-    "@web3auth/base": ^4.0.0
-    "@web3auth/core": ^4.0.0
-    "@web3auth/openlogin-adapter": ^4.1.0
-    "@web3auth/torus-wallet-connector-plugin": ^4.0.0
-    base-64: ^1.0.0
-    dexie: ^3.2.4
-    dexie-react-hooks: ^1.1.7
-    ethers: 5.7.2
-    eventemitter3: ^4.0.7
-    lz-string: ^1.5.0
-    moment: 2.29.4
-    multiformats: 9.9.0
-    posthog-react-native: 2.8.1
-    react-native-indicative: ^0.2.1
-    react-native-restart: ^0.0.24
-    react-use-promise: ^0.5.0
-  peerDependencies:
-    "@react-native-async-storage/async-storage": 1.17.10
-    "@reown/appkit": 1.*
-    "@reown/appkit-adapter-wagmi": 1.*
-    "@tanstack/react-query": 5.*
-    "@usedapp/core": "*"
-    react: ">=17"
-    react-native: "*"
-    react-native-web: "*"
-    viem: 2.*
-    wagmi: 2.*
-  checksum: 36430249c7e61432008d5a17e50b88fd53e61ae524b598db7d93c77824eaad7d96a1b8ef2ecca7293b4970b3b10a55b7fa3674c606622baea725deb520bf13f4
-  languageName: node
-  linkType: hard
 
 "@gooddollar/web3sdk@workspace:packages/sdk":
   version: 0.0.0-use.local


### PR DESCRIPTION
## Summary by Sourcery

Update gas fee handling to use provider fee data with sensible defaults and adjust consumers accordingly.

New Features:
- Expose full fee data (gasPrice, maxFeePerGas, maxPriorityFeePerGas, lastBaseFeePerGas) from useGasFees instead of only gasPrice.

Enhancements:
- Initialize gas fee state with higher default values and asynchronously refresh from the connected provider.
- Simplify default gas overrides in useContractFunctionWithDefaultGasFees to derive max fees from the current gasPrice instead of hardcoded per-chain values.
- Update claim and faucet hooks to derive minimum balance from the shared useGasFees hook rather than local gasPrice defaults.
- Change Storybook Web3 wrapper to use Celo as the read-only chain instead of XDC.