### PR TITLE
feat(web3sdk-v2): prefer BUYGDFactoryV3 and bump goodprotocol

### DIFF
--- a/packages/sdk-v2/package.json
+++ b/packages/sdk-v2/package.json
@@ -82,7 +82,7 @@
     "@gooddollar/bridge-contracts": "^1.0.17",
     "@gooddollar/goodcollective-contracts": "^1.3.0",
     "@gooddollar/goodcollective-sdk": "^1.3.3",
-    "@gooddollar/goodprotocol": "^2.2.1",
+    "@gooddollar/goodprotocol": "^2.3.3",
     "@react-native-community/geolocation": "3.1.0",
     "@react-native-firebase/analytics": "^16.4.6",
     "@sentry/browser": "7.16.0",

--- a/packages/sdk-v2/src/sdk/buygd/react.tsx
+++ b/packages/sdk-v2/src/sdk/buygd/react.tsx
@@ -29,7 +29,7 @@ export const useBuyGd = ({
   const devEnv = baseEnv === "fuse" ? "development" : baseEnv;
   const { backend } = Envs[devEnv];
   const buyGdFactory = new Contract(
-    contractAddresses[connectedEnv].BUYGDFactoryV3 || contractAddresses[connectedEnv].BuyGDFactoryV2,
+    contractAddresses[connectedEnv].BUYGDFactoryV3 ?? contractAddresses[connectedEnv].BuyGDFactoryV2,
     buygdAbi
   );
 

--- a/packages/sdk-v2/src/sdk/buygd/react.tsx
+++ b/packages/sdk-v2/src/sdk/buygd/react.tsx
@@ -28,7 +28,10 @@ export const useBuyGd = ({
   const { baseEnv, connectedEnv } = useGetEnvChainId(42220);
   const devEnv = baseEnv === "fuse" ? "development" : baseEnv;
   const { backend } = Envs[devEnv];
-  const buyGdFactory = new Contract(contractAddresses[connectedEnv].BuyGDFactoryV2, buygdAbi);
+  const buyGdFactory = new Contract(
+    contractAddresses[connectedEnv].BUYGDFactoryV3 || contractAddresses[connectedEnv].BuyGDFactoryV2,
+    buygdAbi
+  );
 
   const targetGDHelper = useCall(
     account &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -6032,6 +6032,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gooddollar/goodprotocol@npm:^2.3.3":
+  version: 2.3.3
+  resolution: "@gooddollar/goodprotocol@npm:2.3.3"
+  checksum: e88ac253ba462045a2b6eeacf11995cd6134ad1ac919e7142b1a25166a581ae891444585245ac8e6c9ac1f5c7188720b3e343cc082906913784cc2e944ebd686
+  languageName: node
+  linkType: hard
+
 "@gooddollar/web3sdk-v2@*, @gooddollar/web3sdk-v2@workspace:packages/sdk-v2":
   version: 0.0.0-use.local
   resolution: "@gooddollar/web3sdk-v2@workspace:packages/sdk-v2"
@@ -6048,7 +6055,7 @@ __metadata:
     "@gooddollar/bridge-contracts": ^1.0.17
     "@gooddollar/goodcollective-contracts": ^1.3.0
     "@gooddollar/goodcollective-sdk": ^1.3.3
-    "@gooddollar/goodprotocol": ^2.2.1
+    "@gooddollar/goodprotocol": ^2.3.3
     "@react-native-async-storage/async-storage": 1.17.10
     "@react-native-community/geolocation": 3.1.0
     "@react-native-firebase/analytics": ^16.4.6


### PR DESCRIPTION
# Description

- Bump `@gooddollar/goodprotocol` from `^2.2.1` to `^2.3.3` so deployment addresses include `BUYGDFactoryV3`.
- Update `useBuyGd` to use `BUYGDFactoryV3` when present, falling back to `BuyGDFactoryV2`.



About # (link your issue here)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [ ] PR title matches follow: (Feature|Bug|Chore) Task Name
- [ ] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes

## Summary by Sourcery

Prefer BUYGDFactoryV3 in the web3 SDK buy flow while updating protocol dependencies.

New Features:
- Select BUYGDFactoryV3 for buy operations when available, with automatic fallback to the V2 factory.

Enhancements:
- Upgrade @gooddollar/goodprotocol dependency to version ^2.3.3 to align deployment addresses with the new factory contract.